### PR TITLE
Composer update to make install directory shorter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
             "name": "Michael Strong",
             "email": "mstrong@silverstripe.org"
         }
-    ]
+    ],
+    "extra": {
+		"installer-name": "lumberjack"
+	}
 }


### PR DESCRIPTION
Makes the directory named `lumberjack` when installed via composer instead of `silverstripe-lumberjack`.