### PR TITLE
More broad check for CMS Controller

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -108,7 +108,7 @@ class Lumberjack extends Hierarchy {
 	 */
 	protected function shouldFilter() {
 		$controller = Controller::curr();
-		return get_class($controller) == "CMSPagesController"
+		return $controller instanceof LeftAndMain
 			&& in_array($controller->getAction(), array("treeview", "listview", "getsubtree"));
 	}
 


### PR DESCRIPTION
This checks if the $controller is an instanceof LeftAndMain for a looser coupling to the CMS Controllers. This would allow coupling this extension to custom CMS controllers.
