### PR TITLE
Added Default String to "Modified" _t() Function

### DIFF
--- a/code/forms/gridfield/GridFieldSiteTreeState.php
+++ b/code/forms/gridfield/GridFieldSiteTreeState.php
@@ -30,7 +30,7 @@ class GridFieldSiteTreeState implements GridField_ColumnProvider {
 			if($record->hasMethod("isPublished")) {
 				$modifiedLabel = "";
 				if($record->isModifiedOnStage) {
-					$modifiedLabel = "<span class='modified'>" . _t("GridFieldSiteTreeState.Modified") . "</span>";
+					$modifiedLabel = "<span class='modified'>" . _t("GridFieldSiteTreeState.Modified", "Modified") . "</span>";
 				} 
 
 				$published = $record->isPublished();


### PR DESCRIPTION
As the lang dir hasn't been brought over into Lumberjack from Blogger, the "Modified" _t() function had nothing to output by default. So the "Modified" label would not display correctly in the gridfield.

Before: 
![](http://spdr.me/1bw2N+)
After: 
![](http://spdr.me/1gpvU+)
