### PR TITLE
if only one excluded class, use it as the basis for the DataObject get

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -37,10 +37,20 @@ class Lumberjack extends Hierarchy {
 	public function updateCMSFields(FieldList $fields) {
 		$excluded = $this->owner->getExcludedSiteTreeClassNames();
 		if(!empty($excluded)) {
-			$pages = SiteTree::get()->filter(array(
-				'ParentID' => $this->owner->ID,
-				'ClassName' => $excluded
-			));
+
+			// if we only have one $excluded class, use it instead of SiteTree
+			if (count($excluded) == 1) {
+				$pages = DataList::create(array_keys($excluded)[0])->filter(array(
+					'ParentID' => $this->owner->ID,
+					'ClassName' => $excluded
+				));
+			}
+			else {
+				$pages = SiteTree::get()->filter(array(
+					'ParentID' => $this->owner->ID,
+					'ClassName' => $excluded
+				));
+			}
 			$gridField = new GridField(
 				"ChildPages",
 				$this->getLumberjackTitle(),

--- a/code/forms/gridfield/GridFieldSiteTreeState.php
+++ b/code/forms/gridfield/GridFieldSiteTreeState.php
@@ -30,7 +30,7 @@ class GridFieldSiteTreeState implements GridField_ColumnProvider {
 			if($record->hasMethod("isPublished")) {
 				$modifiedLabel = "";
 				if($record->isModifiedOnStage) {
-					$modifiedLabel = "<span class='modified'>" . _t("GridFieldSiteTreeState.Modified") . "</span>";
+					$modifiedLabel = "<span class='modified'>" . _t("GridFieldSiteTreeState.Modified",'Modified') . "</span>";
 				} 
 
 				$published = $record->isPublished();


### PR DESCRIPTION
This minor tweak makes it so if you only have one child class, the DataObject get will be based on that child class instead of SiteTree. This was the grid field can pick up things like default_sort and summary_fields.

Hope this is helpful!

Thanks for this excellent module! I think we will use this all the time!

-Phil
