### PR TITLE
Reverts the ChildPages tab insertion method

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -48,8 +48,7 @@ class Lumberjack extends Hierarchy {
 				GridFieldConfig_Lumberjack::create()
 			);
 
-			$tab = new Tab('ChildPages', $this->getLumberjackTitle(), $gridField);
-			$fields->insertAfter($tab, 'Main');
+			$fields->addFieldToTab("Root.".$this->getLumberjackTitle(), $gridField);
 		}
 	}
 


### PR DESCRIPTION
Reverts the insertion of the `ChildPages` tab to use `addFieldToTab()` (as used in Blogger) instead of `insertAfter()` to allow developers to specify themselves if this tab should appear before or after the `Root.Main` tab.

It is not possible to override `insertAfter()`, but it is possible to override `addFieldToTab()`.

_Resolves issue #10_
