### PR TITLE
Ability to Specify ClassName for Gridfield

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -37,7 +37,8 @@ class Lumberjack extends Hierarchy {
 	public function updateCMSFields(FieldList $fields) {
 		$excluded = $this->owner->getExcludedSiteTreeClassNames();
 		if(!empty($excluded)) {
-			$pages = SiteTree::get()->filter(array(
+			$childClassName = $this->getChildClassName();
+			$pages = $childClassName::get()->filter(array(
 				'ParentID' => $this->owner->ID,
 				'ClassName' => $excluded
 			));
@@ -110,6 +111,22 @@ class Lumberjack extends Hierarchy {
 		$controller = Controller::curr();
 		return $controller instanceof LeftAndMain
 			&& in_array($controller->getAction(), array("treeview", "listview", "getsubtree"));
+	}
+	
+	/**
+	 * Checks config for a specified child_classname on the class extending Lumberjack.
+	 * Uses SiteTree if none found in config.
+	 *
+	 * @return string
+	 */
+	protected function getChildClassName() {
+		$childClassName = "SiteTree";
+		if ($childClassNameConfig = Injector::inst()->create($this->owner->ClassName)->config()->child_classname) {
+			if (class_exists($childClassNameConfig)) {
+				$childClassName = $childClassNameConfig;
+			}
+		}
+		return $childClassName;
 	}
 
 }


### PR DESCRIPTION
Developer can add a config option to use a specific class name in the gridfield, rather than just `SiteTree`. This allows the gridfield to make use of the child class's `default_sort`, resolving issue #3.

Example config:

```
NewsHolder:
  extensions:
    - 'Lumberjack'
  child_classname: NewsArticle
```

If the `child_classname` config item doesn't exist, is empty, or doesn't contain the name of an existing class, then `SiteTree` is used.
