### PR TITLE
FIX: liveChildren() should return $staged if !shouldFilter()

### DIFF
--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -84,6 +84,8 @@ class Lumberjack extends Hierarchy {
 			// Filter the SiteTree
 			return $staged->exclude("ClassName", $this->owner->getExcludedSiteTreeClassNames());
 		}
+		
+		return $staged;
 	}
 
 


### PR DESCRIPTION
stageChildren() returns the unmodified parent::stageChildren() value if it's not a page/controller that Lumberjack filters on
