### PR TITLE
Switching $show_in_sitetree via CMS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
 before_script:
   - phpenv rehash
-  - composer self-update
+  - composer self-update || true
   - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
   - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
   - cd ~/builds/ss

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,20 @@ language: php
 
 sudo: false
 
+php:
+  - 5.3
+
 env:
-  global:
-    - DB=MYSQL CORE_RELEASE=3.1
+  - DB=MYSQL CORE_RELEASE=3.1
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=MYSQL
-    - php: 5.5
-      env: DB=MYSQL
     - php: 5.4
-      env: DB=MYSQL
-    - php: 5.3
-      env: DB=MYSQL
+      env: DB=MYSQL CORE_RELEASE=3.1
+    - php: 5.5
+      env: DB=MYSQL CORE_RELEASE=3
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.2
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ matrix:
       env: DB=MYSQL
     - php: 5.3
       env: DB=MYSQL
-    - php: hhvm-nightly
-      env: DB=MYSQL
-      before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install -y tidy
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 env:
   global:
     - DB=MYSQL CORE_RELEASE=3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ before_script:
   - cd ~/builds/ss
 
 script:
-  - phpunit silverstripe-lumberjack/tests/
+  - vendor/bin/phpunit lumberjack/tests/

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[silverstripe-lumberjack.master]
+file_filter = lang/<lang>.yml
+source_file = lang/en.yml
+source_lang = en
+type = YML

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SilverStripe Lumberjack
 
-[![Build Status](https://travis-ci.org/micmania1/silverstripe-lumberjack.png?branch=master)](https://travis-ci.org/micmania1/silverstripe-lumberjack) [![Latest Stable Version](https://poser.pugx.org/micmania1/silverstripe-lumberjack/v/stable.svg)](https://packagist.org/packages/micmania1/silverstripe-lumberjack) [![Total Downloads](https://poser.pugx.org/micmania1/silverstripe-lumberjack/downloads.svg)](https://packagist.org/packages/micmania1/silverstripe-lumberjack) [![Latest Unstable Version](https://poser.pugx.org/micmania1/silverstripe-lumberjack/v/unstable.svg)](https://packagist.org/packages/micmania1/silverstripe-lumberjack) [![License](https://poser.pugx.org/micmania1/silverstripe-lumberjack/license.svg)](https://packagist.org/packages/micmania1/silverstripe-lumberjack)
+[![Build Status](https://travis-ci.org/silverstripe/silverstripe-lumberjack.svg?branch=1.1)](https://travis-ci.org/silverstripe/silverstripe-lumberjack) [![Latest Stable Version](https://poser.pugx.org/silverstripe/lumberjack/v/stable)](https://packagist.org/packages/silverstripe/lumberjack) [![Latest Unstable Version](https://poser.pugx.org/silverstripe/lumberjack/v/unstable)](https://packagist.org/packages/silverstripe/lumberjack) [![License](https://poser.pugx.org/silverstripe/lumberjack/license)](https://packagist.org/packages/silverstripe/lumberjack)
 
 A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module was born out of and decoupled from [micmania1/silverstripe-blog](htt
 
 ## Installation
 
-	composer require silverstripe/silverstripe-lumberjack
+	composer require silverstripe/lumberjack
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module was born out of and decoupled from [micmania1/silverstripe-blog](htt
 
 ## Installation
 
-	composer require micmania1/silverstripe-lumberjack
+	composer require silverstripe/silverstripe-lumberjack
 
 ## Features
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.4]
+
+* Update translations.
+* If Translatable is active, set the Locale for new records
+
 ## [1.1.3]
 
 * Changelog added

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.1.3]
+
+* Changelog added
+* Update translations
+* Update README.md
+* fixing composer require statement
+* filter hide_ancestor hidden page types from dropdown
+* BUG Fix creation of duplicate ParentID field on subtables of SiteTree
+* Add 3.2 and php 5.6 tests

--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -108,7 +108,7 @@ class Lumberjack extends Hierarchy {
 	 */
 	protected function shouldFilter() {
 		$controller = Controller::curr();
-		return get_class($controller) == "CMSPagesController"
+		return $controller instanceof LeftAndMain
 			&& in_array($controller->getAction(), array("treeview", "listview", "getsubtree"));
 	}
 

--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -21,7 +21,7 @@ class Lumberjack extends Hierarchy {
 		$classes = array();
 		$siteTreeClasses = $this->owner->allowedChildren();
 		foreach($siteTreeClasses as $class) {
-			if(Injector::inst()->create($class)->config()->show_in_sitetree === false) {
+			if(Config::inst()->get($class, 'show_in_sitetree') === false) {
 				$classes[$class] = $class;
 			}
 		}

--- a/code/extensions/Lumberjack.php
+++ b/code/extensions/Lumberjack.php
@@ -57,9 +57,10 @@ class Lumberjack extends Hierarchy {
 	/**
 	 * Augments (@link Hierarchy::stageChildren()}
 	 *
-	 * @param $staged DataList
-	 * @param $showAll boolean
-	 **/
+	 * @param boolean showAll Include all of the elements, even those not shown in the menus.
+	 *   (only applicable when extension is applied to {@link SiteTree}).
+	 * @return DataList
+	 */
 	public function stageChildren($showAll = false) {
 		$staged = parent::stageChildren($showAll);
 
@@ -72,11 +73,13 @@ class Lumberjack extends Hierarchy {
 
 
 	/**
-	 * Augments (@link Hierarchy::liveChildren()}
+	 * Augments (@link Hierarchy::liveChildren()} by hiding excluded child classnames
 	 *
-	 * @param $staged DataList
-	 * @param $showAll boolean
-	 **/
+	 * @param boolean $showAll Include all of the elements, even those not shown in the menus.
+	 *   (only applicable when extension is applied to {@link SiteTree}).
+	 * @param boolean $onlyDeletedFromStage Only return items that have been deleted from stage
+	 * @return SS_List
+	 */
 	public function liveChildren($showAll = false, $onlyDeletedFromStage = false) {
 		$staged = parent::liveChildren($showAll, $onlyDeletedFromStage);
 
@@ -84,6 +87,7 @@ class Lumberjack extends Hierarchy {
 			// Filter the SiteTree
 			return $staged->exclude("ClassName", $this->owner->getExcludedSiteTreeClassNames());
 		}
+		return $staged;
 	}
 
 

--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -24,6 +24,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 			return array();
 		}
 
+		$nonHiddenPageTypes = SiteTree::page_type_classes();
 		$allowedChildren = $parent->allowedChildren();
 		$children = array();
 		foreach($allowedChildren as $class) {
@@ -32,7 +33,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 				// Note: Second argument to SiteTree::canCreate will support inherited permissions
 				// post 3.1.12, and will default to the old permission model in 3.1.11 or below
 				// See http://docs.silverstripe.org/en/changelogs/3.1.11
-				if($instance->canCreate(null, array('Parent' => $parent))) {
+				if($instance->canCreate(null, array('Parent' => $parent)) && in_array($class, $nonHiddenPageTypes)) {
 					$children[$class] = $instance->i18n_singular_name();
 				}
 			}

--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -120,6 +120,12 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 				"PageType" => $tmpData['pageType']
 			);
 
+			// If Translatable is active, set the Locale (this will no longer be needed after a post-2.1.1
+			// Translatable patch; see https://github.com/silverstripe/silverstripe-lumberjack/pull/32 for more info)
+			if(singleton('SiteTree')->hasExtension('Translatable')) {
+				$data['Locale'] = Translatable::get_current_locale();
+			}
+
 			$controller = Injector::inst()->create("CMSPageAddController");
 
 			$form = $controller->AddForm();

--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -19,7 +19,7 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 	 * @param SiteTree $parent
 	 * @return boolean
 	 */
-	public function getAllowedChildren(SiteTree $parent) {
+	public function getAllowedChildren(SiteTree $parent = null) {
 		if(!$parent || !$parent->canAddChildren()) {
 			return array();
 		}

--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -20,7 +20,10 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 	 * @return boolean
 	 */
 	public function getAllowedChildren(SiteTree $parent) {
-		if(!$parent->canAddChildren()) return array();
+		if(!$parent || !$parent->canAddChildren()) {
+			return array();
+		}
+
 		$allowedChildren = $parent->allowedChildren();
 		$children = array();
 		foreach($allowedChildren as $class) {
@@ -38,9 +41,13 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 	}
 
 	public function getHTMLFragments($gridField) {
-		$parent = SiteTree::get()->byId(Controller::curr()->currentPageID());
 		$state = $gridField->State->GridFieldSiteTreeAddNewButton;
-		$state->currentPageID = $parent->ID;
+
+		$parent = SiteTree::get()->byId(Controller::curr()->currentPageID());
+
+		if($parent) {
+			$state->currentPageID = $parent->ID;
+		}
 
 		$children = $this->getAllowedChildren($parent);
 		if(empty($children)) {

--- a/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
+++ b/code/forms/gridfield/GridFieldSiteTreeAddNewButton.php
@@ -35,10 +35,15 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 			return array();
 		}
 
+		$state = $gridField->State->GridFieldSiteTreeAddNewButton;
+		$state->currentPageID = $parent->ID;
+
 		$children = $this->getAllowedChildren($parent);
 		if(count($children) > 1) {
 			$pageTypes = DropdownField::create("PageType", "Page Type", $children, $model->defaultChild());
 			$pageTypes->setFieldHolderTemplate("GridFieldSiteTreeAddNewButton_holder")->addExtraClass("gridfield-dropdown no-change-track");
+
+			$state->pageType = $parent->defaultChild();
 
 			if(!$this->buttonName) {
 				$this->buttonName = _t('GridFieldSiteTreeAddNewButton.AddMultipleOptions', 'Add new', "Add button text for multiple options.");
@@ -47,14 +52,12 @@ class GridFieldSiteTreeAddNewButton extends GridFieldAddNewButton
 			$keys = array_keys($children);
 			$pageTypes = HiddenField::create('PageType', 'Page Type', $keys[0]);
 
+			$state->pageType = $keys[0];
+
 			if(!$this->buttonName) {
 				$this->buttonName = _t('GridFieldSiteTreeAddNewButton.Add', 'Add new {name}', 'Add button text for a single option.', array($children[$keys[0]]));
 			}
 		}
-
-		$state = $gridField->State->GridFieldSiteTreeAddNewButton;
-		$state->currentPageID = $parent->ID;
-		$state->pageType = $parent->defaultChild();
 
 		$addAction = new GridField_FormAction($gridField, 'add', $this->buttonName, 'add', 'add');
 		$addAction->setAttribute('data-icon', 'add')->addExtraClass("no-ajax ss-ui-action-constructive dropdown-action");

--- a/code/forms/gridfield/GridFieldSiteTreeState.php
+++ b/code/forms/gridfield/GridFieldSiteTreeState.php
@@ -30,7 +30,7 @@ class GridFieldSiteTreeState implements GridField_ColumnProvider {
 			if($record->hasMethod("isPublished")) {
 				$modifiedLabel = "";
 				if($record->isModifiedOnStage) {
-					$modifiedLabel = "<span class='modified'>" . _t("GridFieldSiteTreeState.Modified") . "</span>";
+					$modifiedLabel = "<span class='modified'>" . _t("GridFieldSiteTreeState.Modified", "Modified") . "</span>";
 				} 
 
 				$published = $record->isPublished();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "micmania1/silverstripe-lumberjack",
+    "name": "silverstripe/lumberjack",
     "description": "A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.",
     "type": "silverstripe-module",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,18 @@
 {
-    "name": "silverstripe/lumberjack",
-    "description": "A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.",
-    "type": "silverstripe-module",
-    "require": {
-        "silverstripe/cms": "~3.1"
-    },
-    "license": "BSD-2-Clause",
-    "authors": [
-        {
-            "name": "Michael Strong",
-            "email": "mstrong@silverstripe.org"
-        }
-    ]
+	"name": "silverstripe/lumberjack",
+	"description": "A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.",
+	"type": "silverstripe-module",
+	"require": {
+		"silverstripe/cms": "~3.1"
+	},
+	"require-dev": {
+		"phpunit/PHPUnit": "~3.7@stable"
+	},
+	"license": "BSD-2-Clause",
+	"authors": [
+		{
+			"name": "Michael Strong",
+			"email": "mstrong@silverstripe.org"
+		}
+	]
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.",
 	"type": "silverstripe-module",
 	"require": {
-		"silverstripe/cms": "~3.1"
+		"silverstripe/cms": ">=3.1.0"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
 	"description": "A module to make managing pages in a GridField easy without losing any of the functionality that you're used to in the CMS.",
 	"type": "silverstripe-module",
 	"require": {
-		"silverstripe/cms": ">=3.1.0"
+		"silverstripe/framework": "^3.1",
+		"silverstripe/cms": "^3.1"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,0 +1,7 @@
+de:
+  GridFieldSiteTreeAddNewButton:
+    Add: 'Neuen {name} hinzufügen'
+    AddMultipleOptions: 'Neuen hinzufügen'
+  GridFieldSiteTreeState:
+    Modified: Geändert
+    StateTitle: Status

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -3,5 +3,9 @@ de:
     Add: 'Neuen {name} hinzufügen'
     AddMultipleOptions: 'Neuen hinzufügen'
   GridFieldSiteTreeState:
+    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Als Entwurf am {date} gespeichert'
     Modified: Geändert
+    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Veröffentlicht am {date}'
     StateTitle: Status
+  Lumberjack:
+    TabTitle: 'Unterseiten'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,11 @@
+en:
+  GridFieldSiteTreeAddNewButton:
+    Add: 'Add new {name}'
+    AddMultipleOptions: 'Add new'
+  GridFieldSiteTreeState:
+    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Saved as Draft on {date}'
+    Modified: Modified
+    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Published on {date}'
+    StateTitle: State
+  Lumberjack:
+    TabTitle: 'Child Pages'

--- a/lang/fa_IR.yml
+++ b/lang/fa_IR.yml
@@ -1,0 +1,9 @@
+fa_IR:
+  GridFieldSiteTreeAddNewButton:
+    Add: 'افزودن {name} جدید'
+    AddMultipleOptions: 'افزودن جدید'
+  GridFieldSiteTreeState:
+    Modified: اصلاح شده
+    StateTitle: وضیعت
+  Lumberjack:
+    TabTitle: 'صفحات زیرین'

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -1,0 +1,11 @@
+fi:
+  GridFieldSiteTreeAddNewButton:
+    Add: 'Lisää uusi {name}'
+    AddMultipleOptions: 'Lisää uusi'
+  GridFieldSiteTreeState:
+    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Tallennettu luonnoksena {date}'
+    Modified: Muokattu
+    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Julkaistu {date}'
+    StateTitle: Tila
+  Lumberjack:
+    TabTitle: 'Alasivut'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,0 +1,11 @@
+nl:
+  GridFieldSiteTreeAddNewButton:
+    Add: 'Voeg nieuwe {name} toe'
+    AddMultipleOptions: 'Voeg nieuwe toe'
+  GridFieldSiteTreeState:
+    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Opgeslagen als concept op {date}'
+    Modified: Aangepast
+    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Gepubliceerd op {date}'
+    StateTitle: Status
+  Lumberjack:
+    TabTitle: 'Onderliggende pagina''s'

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -1,11 +1,10 @@
 sk:
   GridFieldSiteTreeAddNewButton:
     Add: 'Pridať {name}'
-    AddMultipleOption: 'Pridať nový'
   GridFieldSiteTreeState:
     Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Uložený ako koncept: {date}'
     Modified: zmenené
     Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Publikovaný: {date}'
     StateTitle: Stav
   Lumberjack:
-    TabTitle: Podstránky
+    TabTitle: 'Podstránky'

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -1,6 +1,7 @@
 sk:
   GridFieldSiteTreeAddNewButton:
     Add: 'Pridať {name}'
+    AddMultipleOptions: 'Pridať'
   GridFieldSiteTreeState:
     Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Uložený ako koncept: {date}'
     Modified: zmenené

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -1,0 +1,11 @@
+sk:
+  GridFieldSiteTreeAddNewButton:
+    Add: 'Pridať {name}'
+    AddMultipleOption: 'Pridať nový'
+  GridFieldSiteTreeState:
+    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Uložený ako koncept: {date}'
+    Modified: zmenené
+    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Publikovaný: {date}'
+    StateTitle: Stav
+  Lumberjack:
+    TabTitle: Podstránky


### PR DESCRIPTION
Would love to see a an option in the CMS page settings that allows users to change the state of $show_in_sitetree on the fly. This would allow users to take advantage of the bulk actions in Site Tree that are not currently available in the grid field by temporarily changing the setting to True.
